### PR TITLE
Upgrade ROTP dependency

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport',  '< 6.1'
   s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 4', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
-  s.add_runtime_dependency 'rotp',           '~> 2.0'
+  s.add_runtime_dependency 'rotp',           '~> 4.0'
 
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'appraisal'

--- a/lib/devise_two_factor/models/two_factor_authenticatable.rb
+++ b/lib/devise_two_factor/models/two_factor_authenticatable.rb
@@ -32,7 +32,9 @@ module Devise
         return false unless code.present? && otp_secret.present?
 
         totp = self.otp(otp_secret)
-        return consume_otp! if totp.verify_with_drift(code, self.class.otp_allowed_drift)
+        if totp.verify(code, drift_ahead: self.class.otp_allowed_drift, drift_behind: self.class.otp_allowed_drift)
+          return consume_otp!
+        end
 
         false
       end

--- a/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_authenticatable_shared_examples.rb
@@ -54,7 +54,7 @@ RSpec.shared_examples 'two_factor_authenticatable' do
       end
 
       context 'given a previously valid OTP within the allowed drift' do
-        let(:consumed_otp) { ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift, true) }
+        let(:consumed_otp) { ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift) }
 
         before do
           subject.validate_and_consume_otp!(consumed_otp)
@@ -77,17 +77,17 @@ RSpec.shared_examples 'two_factor_authenticatable' do
     end
 
     it 'validates an OTP within the allowed drift' do
-      otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift, true)
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift)
       expect(subject.validate_and_consume_otp!(otp)).to be true
     end
 
     it 'does not validate an OTP above the allowed drift' do
-      otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift * 2, true)
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now + subject.class.otp_allowed_drift * 2)
       expect(subject.validate_and_consume_otp!(otp)).to be false
     end
 
     it 'does not validate an OTP below the allowed drift' do
-      otp = ROTP::TOTP.new(otp_secret).at(Time.now - subject.class.otp_allowed_drift * 2, true)
+      otp = ROTP::TOTP.new(otp_secret).at(Time.now - subject.class.otp_allowed_drift * 2)
       expect(subject.validate_and_consume_otp!(otp)).to be false
     end
   end
@@ -102,8 +102,8 @@ RSpec.shared_examples 'two_factor_authenticatable' do
     end
 
     it 'should return uri with issuer option' do
-      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{account}\?.*secret=\w{#{otp_secret_length}}(&|$)})
-      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{account}\?.*issuer=#{issuer}(&|$)})
+      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{issuer}:#{account}\?.*secret=\w{#{otp_secret_length}}(&|$)})
+      expect(subject.otp_provisioning_uri(account, issuer: issuer)).to match(%r{otpauth://totp/#{issuer}:#{account}\?.*issuer=#{issuer}(&|$)})
     end
   end
 end


### PR DESCRIPTION
This required 3 minor updates to accommodate the evolution of ROTP away from DTF's use of it.

There was a [6-month old issue](https://github.com/tinfoil/devise-two-factor/issues/163) requesting this upgrade (and even [a similar PR](https://github.com/tinfoil/devise-two-factor/pull/167) that I later found confirming my own changes), but no response, and we needed to protect ourselves against future problems heralded by the warnings.